### PR TITLE
Change tilde expansion to home specifier

### DIFF
--- a/steam-desktop.service
+++ b/steam-desktop.service
@@ -3,7 +3,7 @@ Description=Steam Desktop Insert
 
 [Service]
 # Command to execute when the service is started
-ExecStart=~/.local/bin/watch.py
+ExecStart=%h/.local/bin/watch.py
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Had an issue on an immutable distro, where systemd couldn't find my home directory for some reason, using a home specifier instead of the tilde expansion should be more universal and fixed the issue.